### PR TITLE
Use copied source array before concatenating files

### DIFF
--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -76,6 +76,7 @@ function run (filePaths, opts, cb) {
  * path to the new file.
  */
 function concatFiles (filePaths, cb) {
+  filePaths = filePaths.slice(0);
   tmp.file(function (er, tmpMdPath, tmpMdFd) {
     if (er) return cb(er)
     fs.close(tmpMdFd)


### PR DESCRIPTION
In grunt-markdown-pdf at https://github.com/alanshaw/grunt-markdown-pdf/blob/master/tasks/markdownpdf.js#L44 `srcs[0]` is used to determine the name of the output PDF.  When using the `concatFiles` option, the `concatFiles` function modifies the file paths array which then leaves `srcs` as an empty array.

This patch fixes the issue by taking a copy by value of the file paths array before iterating over it.
