### PR TITLE
Added page header and footer option; Resolves #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Default value: `1cm`
 
 Supported dimension units are: 'mm', 'cm', 'in', 'px'
 
+#### options.runningsPath
+Type: `String`
+Default value: `runnings.js`
+
+Path to CommonJS module which sets the page header and footer (see [runnings.js](lib/runnings.js))
+
 #### options.renderDelay
 Type: `Number`
 Default value: `1000`
@@ -201,6 +207,7 @@ Options:
   -V, --version                          output the version number
   <markdown-file-path>                   Path of the markdown file to convert
   -p, --phantom-path [path]              Path to phantom binary
+  -h, --runnings-path [path]             Path to runnings (header, footer)
   -s, --css-path [path]                  Path to custom CSS file
   -f, --paper-format [format]            'A3', 'A4', 'A5', 'Legal', 'Letter' or 'Tabloid'
   -r, --paper-orientation [orientation]  'portrait' or 'landscape'

--- a/bin/markdown-pdf
+++ b/bin/markdown-pdf
@@ -8,6 +8,7 @@ program.version(require('../package.json').version)
   .usage('[options] <markdown-file-path>')
   .option('<markdown-file-path>', "Path of the markdown file to convert")
   .option('-p, --phantom-path [path]', "Path to phantom binary")
+  .option('-h, --runnings-path [path]', "Path to runnings (header, footer)")
   .option('-s, --css-path [path]', "Path to custom CSS file")
   .option('-f, --paper-format [format]', "'A3', 'A4', 'A5', 'Legal', 'Letter' or 'Tabloid'")
   .option('-r, --paper-orientation [orientation]', "'portrait' or 'landscape'")
@@ -20,6 +21,7 @@ program.out = program.out || program.args[0].replace(/\.(markdown|md)/g, "") + "
 
 var opts = {
     phantomPath: program.phantomPath
+  , runningsPath: program.runningsPath
   , cssPath: program.cssPath
   , paperFormat: program.paperFormat
   , paperOrientation: program.paperOrientation

--- a/lib-phantom/markdown-pdf.js
+++ b/lib-phantom/markdown-pdf.js
@@ -3,7 +3,7 @@ var system = require("system")
   , fs = require("fs")
 
 // Read in arguments
-var args = ["in", "out", "cssPath", "paperFormat", "paperOrientation", "paperBorder", "renderDelay"].reduce(function (args, name, i) {
+var args = ["in", "out", "runningsPath", "cssPath", "paperFormat", "paperOrientation", "paperBorder", "renderDelay", "jsonPath"].reduce(function (args, name, i) {
   args[name] = system.args[i + 1]
   return args
 }, {})
@@ -45,8 +45,8 @@ page.open(page.libraryPath + "/../html5bp/index.html", function (status) {
   }, fs.read(args.in))
   
   // Set the PDF paper size
-  page.paperSize = {format: args.paperFormat, orientation: args.paperOrientation, border: args.paperBorder}
-  
+  page.paperSize = paperSize(args.runningsPath, {format: args.paperFormat, orientation: args.paperOrientation, border: args.paperBorder})
+
   // Render the page
   setTimeout(function () {
     page.render(args.out)
@@ -55,3 +55,24 @@ page.open(page.libraryPath + "/../html5bp/index.html", function (status) {
   }, parseInt(args.renderDelay, 10))
 })
 
+function paperSize(runningsPath, obj) {
+  var runnings = require(runningsPath)
+
+  // encapsulate .contents into phantom.callback()
+  //   Why does phantomjs not support Array.prototype.forEach?!
+  var keys = ["header", "footer"]
+  for (var i = 0; i < keys.length; i++) {
+    var which = keys[i]
+    if (runnings[which]
+      && runnings[which].contents
+      && typeof runnings[which].contents === "function") {
+      obj[which] = {
+        contents: phantom.callback(runnings[which].contents)
+      }
+      if (runnings[which].height)
+        obj[which].height = runnings[which].height
+    }
+  }
+  
+  return obj
+}

--- a/lib/markdown-pdf.js
+++ b/lib/markdown-pdf.js
@@ -13,6 +13,7 @@ tmp.setGracefulCleanup()
 function markdownpdf (opts) {
   opts = opts || {}
   opts.phantomPath = opts.phantomPath || require("phantomjs").path
+  opts.runningsPath = path.resolve(__dirname + "/..", opts.runningsPath || '') || __dirname + "/runnings.js"
   opts.cssPath = opts.cssPath || __dirname + "/../pdf.css"
   opts.paperFormat = opts.paperFormat || "A4"
   opts.paperOrientation = opts.paperOrientation || "portrait"
@@ -59,6 +60,7 @@ function markdownpdf (opts) {
             path.join(__dirname, "..", "lib-phantom", "markdown-pdf.js")
           , tmpHtmlPath
           , tmpPdfPath
+          , opts.runningsPath
           , opts.cssPath
           , opts.paperFormat
           , opts.paperOrientation

--- a/lib/runnings.js
+++ b/lib/runnings.js
@@ -1,0 +1,15 @@
+exports.header = null
+
+exports.footer = null
+
+/**
+ * header and footer might be of format specified in https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#wiki-webpage-paperSize
+ * 
+ * Example:
+ *  {
+ *    height: "1cm",
+ *    contents: function(pageNum, numPages) {
+ *      return "<h1>Header <span style='float:right'>" + pageNum + " / " + numPages + "</span></h1>"
+ *    }
+ *  }
+ */

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "mocha": "~1.16.2",
     "mocha-lcov-reporter": "0.0.1",
     "coveralls": "~2.6.0",
-    "jscoverage": "~0.3.7"
+    "jscoverage": "~0.3.7",
+    "pdf-text": "~0.3.0"
   },
   "engines": {
     "node": "~0.10.0"

--- a/test/fixtures/runnings.js
+++ b/test/fixtures/runnings.js
@@ -1,0 +1,13 @@
+exports.header = {
+  contents: function(pageNum, numPages) {
+    return "<h1>Some Header <span style='float:right'>" + pageNum + " / " + numPages + "</span></h1>"
+  },
+  height: '1cm'
+}
+
+exports.footer = {
+  contents: function(pageNum, numPages) {
+    return "<h1>Some Footer <span style='float:right'>" + pageNum + " / " + numPages + "</span></h1>"
+  },
+  height: '1cm'
+}

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ var markdownpdf = require("../")
   , fs = require("fs")
   , tmp = require("tmp")
   , through = require("through")
+  , pdfText = require("pdf-text")
 
 tmp.setGracefulCleanup()
 
@@ -24,6 +25,35 @@ describe("markdownpdf", function() {
           // Test not empty
           assert.ok(data.length > 0)
           done()
+        })
+      })
+    })
+  })
+
+  it("should have a header and footer", function (done) {
+    this.timeout(5000)
+
+    tmp.file({postfix: ".pdf"}, function (er, tmpPdfPath, tmpPdfFd) {
+      assert.ifError(er)
+      fs.close(tmpPdfFd)
+
+      markdownpdf({runningsPath: __dirname+'/fixtures/runnings.js'}).from(__dirname + "/fixtures/ipsum.md").to(tmpPdfPath, function (er) {
+        assert.ifError(er)
+
+        // Read the file
+        fs.readFile(tmpPdfPath, {encoding: "utf8"}, function (er, data) {
+          assert.ifError(er)
+          // Test not empty
+          assert.ok(data.length > 0)
+
+          // Header and footer included?
+          pdfText(tmpPdfPath, function (er, chunks) {
+            assert.ifError(er)
+
+            assert.ok(/Some\s?Header/.test(chunks.join('')))
+            assert.ok(/Some\s?Footer/.test(chunks.join('')))
+            done()
+          })
         })
       })
     })


### PR DESCRIPTION
I've added a parameter to pass in a CommonJS (for PhantomJS, you know...) module that sets the pages' header and footer properties as described [here](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage#wiki-webpage-paperSize). By that it is possible to create headers and footers which can contain the page number. Therefore a solution for #12.
