### PR TITLE
Show help for empty arguments

### DIFF
--- a/bin/markdown-pdf
+++ b/bin/markdown-pdf
@@ -18,6 +18,8 @@ program.version(require('../package.json').version)
   .option('-o, --out [path]', "Path of where to save the PDF")
   .parse(process.argv)
 
+if(program.args.length === 0) program.help();
+
 program.out = program.out || program.args[0].replace(/\.m(ark)?d(own)?/gi, "") + ".pdf"
 
 var opts = {


### PR DESCRIPTION
Right now if you just type `markdown-pdf` it displays an error message, because it tries to read the `program.args[0]`, which is empty. Since the `-h` flag also doesn't work (only `--help`) I think it is useful to just show the help page.

So I added that.

Best,
Finn
