### PR TITLE
Allow remarkable options to be set from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Options:
   -h, --runnings-path [path]             Path to runnings (header, footer)
   -s, --css-path [path]                  Path to custom CSS file
   -z, --highlight-css-path [path]        Path to custom highlight-CSS file
+  -m, --remarkable-options [json]        Options to pass to Remarkable
   -f, --paper-format [format]            'A3', 'A4', 'A5', 'Legal', 'Letter' or 'Tabloid'
   -r, --paper-orientation [orientation]  'portrait' or 'landscape'
   -b, --paper-border [measurement]       Supported dimension units are: 'mm', 'cm', 'in', 'px'

--- a/bin/markdown-pdf
+++ b/bin/markdown-pdf
@@ -11,6 +11,7 @@ program.version(require('../package.json').version)
   .option('-h, --runnings-path [path]', "Path to runnings (header, footer)")
   .option('-s, --css-path [path]', "Path to custom CSS file")
   .option('-z, --highlight-css-path [path]', "Path to custom highlight-CSS file")
+  .option('-m, --remarkable-options [json-options]', "Options to pass to remarkable")
   .option('-f, --paper-format [format]', "'A3', 'A4', 'A5', 'Legal', 'Letter' or 'Tabloid'")
   .option('-r, --paper-orientation [orientation]', "'portrait' or 'landscape'")
   .option('-b, --paper-border [measurement]', "Supported dimension units are: 'mm', 'cm', 'in', 'px'")
@@ -29,6 +30,7 @@ var opts = {
   , runningsPath: program.runningsPath
   , cssPath: program.cssPath
   , highlightCssPath: program.highlightCssPath
+  , remarkable: program.remarkableOptions ? JSON.parse(program.remarkableOptions) : undefined
   , paperFormat: program.paperFormat
   , paperOrientation: program.paperOrientation
   , paperBorder: program.paperBorder


### PR DESCRIPTION
This was suggested (#48) and I had a need for the same.

None of the CLI stuff has tests yet, hence so why no tests.