### PR TITLE
Syntax Extension Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Default value: `[]`
 
 An array of Remarkable plugin functions, that extend the markdown parser functionality.
 
+##### options.remarkable.syntax
+Type: `Array` of optional remarkable syntax `Strings`s  
+Default value: `[]`
+
+An array of [optional Remarkable syntax extensions](https://github.com/jonschlinkert/remarkable#syntax-extensions), disabled by default, that extend the markdown parser functionality.
+
 API
 ---
 
@@ -226,7 +232,8 @@ var options = {
     remarkable: {
         html: true,
         breaks: true,
-        plugins: [ require('remarkable-classy') ]
+        plugins: [ require('remarkable-classy') ],
+		syntax: [ 'footnote', 'sup', 'sub' ]
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -64,15 +64,15 @@ function markdownpdf (opts) {
 	  
 	  opts.remarkable.syntax.forEach(function(rule)
 	  {
-		if (rule === 'abbr') {
+		try {
 		  mdParser.core.ruler.enable([rule])
-		}
-		if (rule === 'footnote' || rule === 'deflist') {
+		} catch (er) {}
+		try {
 		  mdParser.block.ruler.enable([rule])
-		}
-		if (rule === 'footnote_inline' || rule === 'ins' || rule === 'mark' || rule === 'sub' || rule === 'sup') {
+		} catch (er) {}
+		try {
 		  mdParser.inline.ruler.enable([rule])
-		}
+		} catch (er) {}
 	  })
 	  
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function markdownpdf (opts) {
   opts.preProcessHtml = opts.preProcessHtml || function () { return through() }
   opts.remarkable = opts.remarkable || {}
   opts.remarkable.plugins = opts.remarkable.plugins || []
+  opts.remarkable.syntax = opts.remarkable.syntax || []
 
   var md = ""
 
@@ -60,6 +61,20 @@ function markdownpdf (opts) {
           mdParser.use(plugin)
         } 
       })
+	  
+	  opts.remarkable.syntax.forEach(function(rule)
+	  {
+		if (rule === 'abbr') {
+		  mdParser.core.ruler.enable([rule])
+		}
+		if (rule === 'footnote' || rule === 'deflist') {
+		  mdParser.block.ruler.enable([rule])
+		}
+		if (rule === 'footnote_inline' || rule === 'ins' || rule === 'mark' || rule === 'sub' || rule === 'sup') {
+		  mdParser.inline.ruler.enable([rule])
+		}
+	  })
+	  
 
       self.push(mdParser.render(md))
       self.push(null)


### PR DESCRIPTION
Remarkable has the ability to [add rules](https://github.com/jonschlinkert/remarkable#manage-rules) to markdown parsing to include:

* Abbreviation  
* Footnotes  
* Definition Lists  
* Superscript  
* Subscript

However, as pointed out in [Issue #67](https://github.com/alanshaw/markdown-pdf/issues/67), markdown-pdf does not include a way to cleanly activate these useful rules.

I've added 15 lines to markdown-pdf/index.js to allow a user to add a `syntax` array to their `options.remarkable` object, allowing full use of all Remarkable has to offer.