### PR TITLE
Fixed #71 - add support for remarkable presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ Default value: `{}`
 
 A config object that is passed to [remarkable](https://www.npmjs.com/package/remarkable#options), the underlying markdown parser.
 
+##### options.remarkable.preset
+Type: `String`
+Default value: `default`
+
+Use remarkable [presets](https://www.npmjs.com/package/remarkable#presets) as a convenience to quickly enable/disable active syntax rules and options for common use cases. 
+
+Supported values are `default`, `commonmark` and `full`
+
 ##### options.remarkable.plugins
 Type: `Array` of remarkable-plugin `Function`s  
 Default value: `[]`

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function markdownpdf (opts) {
   opts.preProcessMd = opts.preProcessMd || function () { return through() }
   opts.preProcessHtml = opts.preProcessHtml || function () { return through() }
   opts.remarkable = opts.remarkable || {}
+  opts.remarkable.preset = opts.remarkable.preset || 'default'
   opts.remarkable.plugins = opts.remarkable.plugins || []
 
   var md = ""
@@ -38,7 +39,7 @@ function markdownpdf (opts) {
     function flush (cb) {
       var self = this
 
-      var mdParser = new Remarkable(extend({
+      var mdParser = new Remarkable(opts.remarkable.preset, extend({
         highlight: function (str, lang) {
           if (lang && hljs.getLanguage(lang)) {
             try {

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ var fs = require("fs")
   , tmp = require("tmp")
   , through = require("through2")
   , pdfText = require("pdf-text")
+  , extend = require("extend")
 
 tmp.setGracefulCleanup()
 
@@ -148,6 +149,30 @@ test("should write to multiple paths when converting multiple files", function (
   })
 })
 
+test("should accept remarkable preset", function(t) {
+  t.plan(2)
+
+  var html = ""
+  var opts = {
+    remarkable: {preset: 'full'},
+    preProcessHtml: function () {
+      return through(
+        function transform (chunk, enc, cb) { html += chunk; cb(); },
+        function flush (cb) {
+          htmlSupTagFound = (html.indexOf("<sup>st</sup>") > -1);
+          t.ok(htmlSupTagFound, "html <sup> tag not found for preset 'full'")
+          cb();
+        }
+      )
+    }
+  }
+
+  // Preset 'full' - expecting <sup>-tag in html
+  markdownpdf(opts).from.string("1^st^ of January").to.string(function (er, pdfStr) {
+    t.ifError(er)
+    t.end()
+  })
+})
 
 test("should initialize remarkable plugins", function(t) {
   t.plan(2)

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,6 @@ var fs = require("fs")
   , tmp = require("tmp")
   , through = require("through2")
   , pdfText = require("pdf-text")
-  , extend = require("extend")
 
 tmp.setGracefulCleanup()
 


### PR DESCRIPTION
Added support for remarkable presets, issue #71, using opts.remarkable.preset field