### PR TITLE
Update node version metadata in package.json and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ node_js:
   - "iojs"
   - "4"
   - "5"
+sudo: false
 after_script:
   - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "iojs"
+  - "4"
+  - "5"
 after_script:
   - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tape": "^4.2.2"
   },
   "engines": {
-    "node": "~0.10.0"
+    "node": ">=0.10.0"
   },
   "bin": {
     "markdown-pdf": "bin/markdown-pdf"


### PR DESCRIPTION
As @codekirei points out in #76, markdown-pdf works with more Node versions than just 0.10. This PR changes `package.json` to reflect that (to silence unnecessary warnings when installing) and instructs Travis CI to test on various other Node versions that also work.

I enabled Travis CI tests on my fork to check that [tests really pass on the specified versions](https://travis-ci.org/anko/markdown-pdf/builds/101443440).

Fixes #76.