### PR TITLE
Change deprecated package.json field "licenses" to "license"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,7 @@
   ],
   "author": "Alan Shaw",
   "homepage": "https://github.com/alanshaw/markdown-pdf",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/alanshaw/markdown-pdf/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "commander": "^2.2.0",
     "duplexer": "^0.1.1",


### PR DESCRIPTION
The "licenses"-property [is deprecated][1], resulting in an error when installing.

The "MIT" string is the correct [SPDX license identifier](https://spdx.org/licenses/), based on the contents of [the `LICENCE` file](https://github.com/alanshaw/markdown-pdf/blob/master/LICENSE).

- - -

Today I learned that "licence" [is a valid spelling](https://en.wikipedia.org/wiki/License) of what I'd usually spell "license". Github's [Licenses API](https://developer.github.com/changes/2015-03-09-licenses-api/) understands it just fine:

```
$ http get https://api.github.com/repos/alanshaw/markdown-pdf/license | jq '.license.name'
"MIT License"
```

[1]: https://docs.npmjs.com/files/package.json#license