### PR TITLE
Update to phantomjs 2.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ tmp.setGracefulCleanup()
 function markdownpdf (opts) {
   opts = opts || {}
   opts.cwd = opts.cwd ? path.resolve(opts.cwd) : process.cwd()
-  opts.phantomPath = opts.phantomPath || require("phantomjs").path
+  opts.phantomPath = opts.phantomPath || require("phantomjs-prebuilt").path
   opts.runningsPath = opts.runningsPath ? path.resolve(opts.runningsPath) : path.join(__dirname, "runnings.js")
   opts.cssPath = opts.cssPath ? path.resolve(opts.cssPath) : path.join(__dirname, "css", "pdf.css")
   opts.highlightCssPath = opts.highlightCssPath ? path.resolve(opts.highlightCssPath) : path.join(__dirname, "css", "highlight.css")

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "duplexer": "^0.1.1",
     "extend": "^3.0.0",
     "highlight.js": "^8.4.0",
-    "phantomjs": "^1.9.13",
+    "phantomjs-prebuilt": "^2.1.3",
     "remarkable": "^1.6.0",
     "stream-from-to": "^1.4.2",
     "through2": "^2.0.0",


### PR DESCRIPTION
The new PhantomJS version can create hyperlink data: links in the output PDF become clickable. Fixes #30. All unit tests also pass, but I've only tested on Linux.

The previous package name "phantomjs" [has been deprecated](https://www.npmjs.com/package/phantomjs#deprecated) in favour of the name "phantomjs-prebuilt": the package and its maintainers are the same.

When testing documents written for the previous version, I noticed some subtle layout changes. I recommend a major version bump.