### PR TITLE
Updated styling to include support for code and blockquotes

### DIFF
--- a/css/pdf.css
+++ b/css/pdf.css
@@ -1,3 +1,37 @@
 body {
-    font-size: 0.625em;
+  font-size: 12px !important;
+}
+
+p {
+  font-size: 12px !important;
+}
+
+pre {
+  background-color: #f7f7f9;
+  color: #000;
+  border: 1px solid #e1e1e8;
+  padding: 9px 14px;
+  border-radius: 5px;
+  font-size: 12px;
+}
+
+pre code {
+  padding: 0px;
+  background-color: transparent !important;
+  border-radius: 0px;
+  color: #000;
+}
+
+code {
+  padding: 2px 4px;
+  background-color: #f9f2f4;
+  color: #c7254e;
+  border-radius: 4px;
+}
+
+blockquote {
+  padding: 10px 20px;
+  margin: 0 0 20px;
+  border: none;
+  border-left: 5px solid #eee;
 }

--- a/phantom/render.js
+++ b/phantom/render.js
@@ -4,9 +4,9 @@ var fs = require('fs')
 var os = require('system').os
 
 // Read in arguments
-var args = ['in', 'out', 'cwd', 'runningsPath', 'cssPath', 'highlightCssPath', 'paperFormat', 'paperOrientation', 'paperBorder', 'renderDelay', 'loadTimeout'].reduce(function (args, name, i) {
-  args[name] = system.args[i + 1]
-  return args
+var args = ['in', 'out', 'cwd', 'runningsPath', 'cssPath', 'highlightCssPath', 'paperFormat', 'paperOrientation', 'paperBorder', 'renderDelay', 'loadTimeout'].reduce(function(args, name, i) {
+    args[name] = system.args[i + 1]
+    return args
 }, {})
 
 var html5bpPath = page.libraryPath + '/../html5bp'
@@ -15,65 +15,82 @@ var html5bpPath = page.libraryPath + '/../html5bp'
 var protocol = os.name === 'windows' ? '' : 'file://'
 
 var html = fs.read(html5bpPath + '/index.html')
-  .replace(/\{\{baseUrl\}\}/g, protocol + html5bpPath)
-  .replace('{{content}}', fs.read(args.in))
+    .replace(/\{\{baseUrl\}\}/g, protocol + html5bpPath)
+    .replace('{{content}}', fs.read(args.in))
 
 page.setContent(html, protocol + args.cwd + '/markdown-pdf.html')
 
 // Add custom CSS to the page
-page.evaluate(function (cssPaths) {
-  var head = document.querySelector('head')
+page.evaluate(function(cssPaths) {
+    var head = document.querySelector('head')
 
-  cssPaths.forEach(function (cssPath) {
-    var css = document.createElement('link')
-    css.rel = 'stylesheet'
-    css.href = cssPath
+    cssPaths.forEach(function(cssPath) {
+        var css = document.createElement('link')
+        css.rel = 'stylesheet'
+        css.href = cssPath
 
-    head.appendChild(css)
-  })
+        var katex = document.createElement('link');
+        katex.rel = 'stylesheet'
+        css.href = 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css'
+
+        var katexJS = document.createElement('script');
+        katexJS.src = 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js';
+
+        var katexAuto = document.createElement('script');
+        katexAuto.src = 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/contrib/auto-render.min.js';
+
+        head.appendChild(css)
+        head.appendChild(katex)
+        head.appendChild(katexJS)
+        head.appendChild(katexAuto)
+    })
 }, [args.cssPath, args.highlightCssPath])
 
 // Set the PDF paper size
-page.paperSize = paperSize(args.runningsPath, {format: args.paperFormat, orientation: args.paperOrientation, border: args.paperBorder})
+page.paperSize = paperSize(args.runningsPath, {
+    format: args.paperFormat,
+    orientation: args.paperOrientation,
+    border: args.paperBorder
+})
 
 args.renderDelay = parseInt(args.renderDelay, 10)
 
 if (args.renderDelay) {
-  setTimeout(render, args.renderDelay)
+    setTimeout(render, args.renderDelay)
 } else {
-  var loadTimeout = setTimeout(render, parseInt(args.loadTimeout, 10))
-  page.onLoadFinished = function () {
-    clearTimeout(loadTimeout)
-    render()
-  }
-}
-
-function render () {
-  page.render(args.out)
-  page.close()
-  window.phantom.exit(0)
-}
-
-function paperSize (runningsPath, obj) {
-  var runnings = require(runningsPath)
-
-  // encapsulate .contents into phantom.callback()
-  //   Why does phantomjs not support Array.prototype.forEach?!
-  var keys = ['header', 'footer']
-
-  for (var i = 0; i < keys.length; i++) {
-    var which = keys[i]
-
-    if (runnings[which] && runnings[which].contents && typeof runnings[which].contents === 'function') {
-      obj[which] = {
-        contents: window.phantom.callback(runnings[which].contents)
-      }
-
-      if (runnings[which].height) {
-        obj[which].height = runnings[which].height
-      }
+    var loadTimeout = setTimeout(render, parseInt(args.loadTimeout, 10))
+    page.onLoadFinished = function() {
+        clearTimeout(loadTimeout)
+        render()
     }
-  }
+}
 
-  return obj
+function render() {
+    page.render(args.out)
+    page.close()
+    window.phantom.exit(0)
+}
+
+function paperSize(runningsPath, obj) {
+    var runnings = require(runningsPath)
+
+    // encapsulate .contents into phantom.callback()
+    //   Why does phantomjs not support Array.prototype.forEach?!
+    var keys = ['header', 'footer']
+
+    for (var i = 0; i < keys.length; i++) {
+        var which = keys[i]
+
+        if (runnings[which] && runnings[which].contents && typeof runnings[which].contents === 'function') {
+            obj[which] = {
+                contents: window.phantom.callback(runnings[which].contents)
+            }
+
+            if (runnings[which].height) {
+                obj[which].height = runnings[which].height
+            }
+        }
+    }
+
+    return obj
 }


### PR DESCRIPTION
Changes affect the styling of: 
- Code blocks

```
example
```
- Single code blocks`example`
- Blockquotes
- A smaller base text size

For a comparison of the two styles on an actual stylesheet, see the attached.
[normal.pdf](https://github.com/alanshaw/markdown-pdf/files/462359/normal.pdf)
[pr.pdf](https://github.com/alanshaw/markdown-pdf/files/462358/pr.pdf)

The styles for the code blocks and the blockquote resemble Bootstraps styles.

Additionally added LaTeX Rendering using KATEX
