### PR TITLE
Change HTML + CSS loading protocol to `file:///` for MS Windows (#65)

### DIFF
--- a/phantom/render.js
+++ b/phantom/render.js
@@ -12,7 +12,8 @@ var args = ['in', 'out', 'cwd', 'runningsPath', 'cssPath', 'highlightCssPath', '
 var html5bpPath = page.libraryPath + '/../html5bp'
 
 // Resources don't load in windows with file protocol
-var protocol = os.name === 'windows' ? '' : 'file://'
+var isWin = os.name === 'windows';
+var protocol = isWin ? 'file:///' : 'file://';
 
 var html = fs.read(html5bpPath + '/index.html')
   .replace(/\{\{baseUrl\}\}/g, protocol + html5bpPath)
@@ -31,7 +32,9 @@ page.evaluate(function (cssPaths) {
 
     head.appendChild(css)
   })
-}, [args.cssPath, args.highlightCssPath])
+}, [args.cssPath, args.highlightCssPath].map(function(cssPath){
+    return (isWin ? protocol : "") + cssPath;
+}))
 
 // Set the PDF paper size
 page.paperSize = paperSize(args.runningsPath, {format: args.paperFormat, orientation: args.paperOrientation, border: args.paperBorder})

--- a/phantom/render.js
+++ b/phantom/render.js
@@ -12,8 +12,8 @@ var args = ['in', 'out', 'cwd', 'runningsPath', 'cssPath', 'highlightCssPath', '
 var html5bpPath = page.libraryPath + '/../html5bp'
 
 // Resources don't load in windows with file protocol
-var isWin = os.name === 'windows';
-var protocol = isWin ? 'file:///' : 'file://';
+var isWin = os.name === 'windows'
+var protocol = isWin ? 'file:///' : 'file://'
 
 var html = fs.read(html5bpPath + '/index.html')
   .replace(/\{\{baseUrl\}\}/g, protocol + html5bpPath)
@@ -32,8 +32,8 @@ page.evaluate(function (cssPaths) {
 
     head.appendChild(css)
   })
-}, [args.cssPath, args.highlightCssPath].map(function(cssPath){
-    return (isWin ? protocol : "") + cssPath;
+}, [args.cssPath, args.highlightCssPath].map(function (cssPath) {
+  return (isWin ? protocol : '') + cssPath
 }))
 
 // Set the PDF paper size


### PR DESCRIPTION
Fixes apply only to Windows system. They are:

- Fixes images not loading correctly
- Custom CSS file not being loaded

I think the changes are safe in that they are only applied if `os.name` is windows.  The solution is heavily driven by the discussion on issue #65. 

---

Anyone finding this pull request and wanting to use/try it this solution before it is merged in: do the following and provide feedback as to whether it worked for you:

```
npm install purtuga/markdown-pdf#master
```

/Paul