### PR TITLE
Added support for paperBorder as object

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ function markdownpdf (opts) {
           opts.highlightCssPath,
           opts.paperFormat,
           opts.paperOrientation,
-          opts.paperBorder,
+          typeof opts.paperBorder === 'object' ? JSON.stringify(opts.paperBorder) : opts.paperBorder,
           opts.renderDelay,
           opts.loadTimeout
         ]

--- a/phantom/render.js
+++ b/phantom/render.js
@@ -34,7 +34,7 @@ page.evaluate(function (cssPaths) {
 }, [args.cssPath, args.highlightCssPath])
 
 // Set the PDF paper size
-page.paperSize = paperSize(args.runningsPath, {format: args.paperFormat, orientation: args.paperOrientation, border: args.paperBorder})
+page.paperSize = paperSize(args.runningsPath, {format: args.paperFormat, orientation: args.paperOrientation, border: isJson(args.paperBorder) ? JSON.parse(args.paperBorder) : args.paperBorder})
 
 args.renderDelay = parseInt(args.renderDelay, 10)
 
@@ -77,3 +77,5 @@ function paperSize (runningsPath, obj) {
 
   return obj
 }
+
+function isJson(str) { try { JSON.parse(str); } catch (e) { return false; } return true; }


### PR DESCRIPTION
Hi, I've added a simple check on paperBorder property to support, as specified here in Phantomjs documentation http://phantomjs.org/api/webpage/property/paper-size.html#margin, margin as object.