### PR TITLE
Use object shorthand for properties

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -93,7 +93,7 @@ test('should call preProcessMd hook', function (t) {
   var writeCount = 0
   var preProcessMd = function () { return through(function (data, enc, cb) { writeCount++; this.push(data); cb() }) }
 
-  markdownpdf({ preProcessMd: preProcessMd }).from(path.join(__dirname, '/fixtures/ipsum.md')).to.string(function (er, pdfStr) {
+  markdownpdf({ preProcessMd }).from(path.join(__dirname, '/fixtures/ipsum.md')).to.string(function (er, pdfStr) {
     t.ifError(er)
 
     // Test not empty
@@ -109,7 +109,7 @@ test('should call preProcessHtml hook', function (t) {
   var writeCount = 0
   var preProcessHtml = function () { return through(function (data, enc, cb) { writeCount++; this.push(data); cb() }) }
 
-  markdownpdf({ preProcessHtml: preProcessHtml }).from(path.join(__dirname, '/fixtures/ipsum.md')).to.string(function (er, pdfStr) {
+  markdownpdf({ preProcessHtml }).from(path.join(__dirname, '/fixtures/ipsum.md')).to.string(function (er, pdfStr) {
     t.ifError(er)
 
     // Test not empty


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166


(re. Node.js compatibility: your `package.json` indicates that Node 0.10 is supported, but there is currently syntax in use that only works on Node.js 6.x, and the tests are run on 10.x. The syntax introduced in this PR is compatible with Node.js 4.x)