### PR TITLE
Add CSS-like syntax support to options.paperBorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ Default value: `2cm`
 
 Supported dimension units are: 'mm', 'cm', 'in', 'px'
 
+`paperBorder` option may be specified using one, two, three or four values:
+
+* `10px`
+  * all sides: 10px
+* `10px 20px`
+  * top and bottom: 10px
+  * left and right: 20px
+* `10px 20px 30px`
+  * top: 10px
+  * left and right: 20px
+  * bottom: 30px
+* `10px 20px 30px 40px`
+  * top: 10px
+  * right: 20px
+  * bottom: 30px
+  * left: 40px 
+
 #### options.runningsPath
 Type: `String`
 Default value: `runnings.js`

--- a/phantom/render.js
+++ b/phantom/render.js
@@ -37,7 +37,11 @@ page.evaluate(function (cssPaths) {
 }))
 
 // Set the PDF paper size
-page.paperSize = paperSize(args.runningsPath, { format: args.paperFormat, orientation: args.paperOrientation, border: isJson(args.paperBorder) ? JSON.parse(args.paperBorder) : args.paperBorder })
+page.paperSize = paperSize(args.runningsPath, {
+  format: args.paperFormat,
+  orientation: args.paperOrientation,
+  border: paperBorder(args.paperBorder)
+})
 
 args.renderDelay = parseInt(args.renderDelay, 10)
 
@@ -79,6 +83,50 @@ function paperSize (runningsPath, obj) {
   }
 
   return obj
+}
+
+function paperBorder (border) {
+  if (isJson(border)) {
+    return JSON.parse(border)
+  }
+
+  var props = border.split(' ')
+
+  for (var i = 0; i < props.length; i++) {
+    if (props[i].length === 0) {
+      props.splice(i, 1)
+      i--
+    }
+  }
+
+  switch (props.length) {
+    case 4:
+      return {
+        top: props[0],
+        right: props[1],
+        bottom: props[2],
+        left: props[3]
+      }
+
+    case 3:
+      return {
+        top: props[0],
+        right: props[1],
+        bottom: props[2],
+        left: props[1]
+      }
+
+    case 2:
+      return {
+        top: props[0],
+        right: props[1],
+        bottom: props[0],
+        left: props[1]
+      }
+
+    case 1:
+      return props[0]
+    }
 }
 
 function isJson (str) { try { JSON.parse(str) } catch (e) { return false } return true }


### PR DESCRIPTION
This change allows `options.paperBorder` to be specified using a simpler, more command-line friendly syntax, similar to the [margin CSS shorthand](https://developer.mozilla.org/en-US/docs/Web/CSS/margin#syntax).

* `10px`
  * all sides: 10px
* `10px 20px`
  * top and bottom: 10px
  * left and right: 20px
* `10px 20px 30px`
  * top: 10px
  * left and right: 20px
  * bottom: 30px
* `10px 20px 30px 40px`
  * top: 10px
  * right: 20px
  * bottom: 30px
  * left: 40px 